### PR TITLE
Fix. Ansible provisioner shows pending changes each time. Make `arguments` and `envs` variables not required

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -15,11 +15,11 @@ resource "null_resource" "provisioner" {
 
   triggers {
     signature = "${data.archive_file.default.output_md5}"
-    command   = "ansible-playbook ${var.dry_run ? "--check --diff" : ""} ${length(compact(concat(var.arguments))) > 0 ? join(" ", var.arguments) : ""} ${length(compact(concat(var.envs))) > 0 ? join(" -e ", var.envs) : ""} ${var.playbook}"
+    command   = "ansible-playbook ${var.dry_run ? "--check --diff" : ""} ${length(compact(concat(var.arguments))) > 0 ? join(" ", var.arguments) : ""} ${length(compact(concat(var.envs))) > 0 ? "-e" : ""} ${length(compact(concat(var.envs))) > 0 ? join(" -e ", var.envs) : ""} ${var.playbook}"
   }
 
   provisioner "local-exec" {
-    command = "ansible-playbook ${var.dry_run ? "--check --diff" : ""} ${length(compact(concat(var.arguments))) > 0 ? join(" ", var.arguments) : ""} ${length(compact(concat(var.envs))) > 0 ? join(" -e ", var.envs) : ""} ${var.playbook}"
+    command = "ansible-playbook ${var.dry_run ? "--check --diff" : ""} ${length(compact(concat(var.arguments))) > 0 ? join(" ", var.arguments) : ""} ${length(compact(concat(var.envs))) > 0 ? "-e" : ""} ${length(compact(concat(var.envs))) > 0 ? join(" -e ", var.envs) : ""} ${var.playbook}"
   }
 
   lifecycle {

--- a/main.tf
+++ b/main.tf
@@ -15,11 +15,11 @@ resource "null_resource" "provisioner" {
 
   triggers {
     signature = "${data.archive_file.default.output_md5}"
-    command   = "ansible-playbook ${var.dry_run ? "--check --diff" : ""} ${join(" ", compact(var.arguments))} ${length(compact(var.envs)) > 0 ? "-e" : ""} ${length(compact(var.envs)) > 0 ? join(" -e ", var.envs) : ""} ${var.playbook}"
+    command   = "ansible-playbook ${var.dry_run ? "--check --diff" : ""} ${join(" ", compact(var.arguments))} ${length(compact(var.envs)) > 0 ? "-e" : ""} ${join(" -e ", compact(var.envs))} ${var.playbook}"
   }
 
   provisioner "local-exec" {
-    command = "ansible-playbook ${var.dry_run ? "--check --diff" : ""} ${join(" ", compact(var.arguments))} ${length(compact(var.envs)) > 0 ? "-e" : ""} ${length(compact(var.envs)) > 0 ? join(" -e ", var.envs) : ""} ${var.playbook}"
+    command = "ansible-playbook ${var.dry_run ? "--check --diff" : ""} ${join(" ", compact(var.arguments))} ${length(compact(var.envs)) > 0 ? "-e" : ""} ${join(" -e ", compact(var.envs))} ${var.playbook}"
   }
 
   lifecycle {

--- a/main.tf
+++ b/main.tf
@@ -15,11 +15,11 @@ resource "null_resource" "provisioner" {
 
   triggers {
     signature = "${data.archive_file.default.output_md5}"
-    command   = "ansible-playbook ${var.dry_run ? "--check --diff" : ""} ${join(" ", compact(var.arguments))} ${length(compact(concat(var.envs))) > 0 ? "-e" : ""} ${length(compact(concat(var.envs))) > 0 ? join(" -e ", var.envs) : ""} ${var.playbook}"
+    command   = "ansible-playbook ${var.dry_run ? "--check --diff" : ""} ${join(" ", compact(var.arguments))} ${length(compact(var.envs)) > 0 ? "-e" : ""} ${length(compact(var.envs)) > 0 ? join(" -e ", var.envs) : ""} ${var.playbook}"
   }
 
   provisioner "local-exec" {
-    command = "ansible-playbook ${var.dry_run ? "--check --diff" : ""} ${join(" ", compact(var.arguments))} ${length(compact(concat(var.envs))) > 0 ? "-e" : ""} ${length(compact(concat(var.envs))) > 0 ? join(" -e ", var.envs) : ""} ${var.playbook}"
+    command = "ansible-playbook ${var.dry_run ? "--check --diff" : ""} ${join(" ", compact(var.arguments))} ${length(compact(var.envs)) > 0 ? "-e" : ""} ${length(compact(var.envs)) > 0 ? join(" -e ", var.envs) : ""} ${var.playbook}"
   }
 
   lifecycle {

--- a/main.tf
+++ b/main.tf
@@ -6,8 +6,6 @@ data "archive_file" "default" {
   type        = "zip"
   source_dir  = "${dirname(var.playbook)}"
   output_path = "${path.module}/${random_id.default.hex}.zip"
-
-  depends_on = ["random_id.default"]
 }
 
 resource "null_resource" "provisioner" {

--- a/main.tf
+++ b/main.tf
@@ -15,11 +15,11 @@ resource "null_resource" "provisioner" {
 
   triggers {
     signature = "${data.archive_file.default.output_md5}"
-    command   = "ansible-playbook ${var.dry_run ? "--check --diff" : ""} ${length(compact(concat(var.arguments))) > 0 ? join(" ", var.arguments) : ""} ${length(compact(concat(var.envs))) > 0 ? "-e" : ""} ${length(compact(concat(var.envs))) > 0 ? join(" -e ", var.envs) : ""} ${var.playbook}"
+    command   = "ansible-playbook ${var.dry_run ? "--check --diff" : ""} ${join(" ", compact(var.arguments))} ${length(compact(concat(var.envs))) > 0 ? "-e" : ""} ${length(compact(concat(var.envs))) > 0 ? join(" -e ", var.envs) : ""} ${var.playbook}"
   }
 
   provisioner "local-exec" {
-    command = "ansible-playbook ${var.dry_run ? "--check --diff" : ""} ${length(compact(concat(var.arguments))) > 0 ? join(" ", var.arguments) : ""} ${length(compact(concat(var.envs))) > 0 ? "-e" : ""} ${length(compact(concat(var.envs))) > 0 ? join(" -e ", var.envs) : ""} ${var.playbook}"
+    command = "ansible-playbook ${var.dry_run ? "--check --diff" : ""} ${join(" ", compact(var.arguments))} ${length(compact(concat(var.envs))) > 0 ? "-e" : ""} ${length(compact(concat(var.envs))) > 0 ? join(" -e ", var.envs) : ""} ${var.playbook}"
   }
 
   lifecycle {

--- a/main.tf
+++ b/main.tf
@@ -15,11 +15,11 @@ resource "null_resource" "provisioner" {
 
   triggers {
     signature = "${data.archive_file.default.output_md5}"
-    command   = "ansible-playbook ${var.dry_run ? "--check --diff" : ""} ${join(" ", var.arguments)} -e ${join(" -e ", var.envs)} ${var.playbook}"
+    command   = "ansible-playbook ${var.dry_run ? "--check --diff" : ""} ${length(compact(concat(var.arguments))) > 0 ? join(" ", var.arguments) : ""} ${length(compact(concat(var.envs))) > 0 ? join(" -e ", var.envs) : ""} ${var.playbook}"
   }
 
   provisioner "local-exec" {
-    command = "ansible-playbook ${var.dry_run ? "--check --diff" : ""} ${join(" ", var.arguments)} -e ${join(" -e ", var.envs)} ${var.playbook}"
+    command = "ansible-playbook ${var.dry_run ? "--check --diff" : ""} ${length(compact(concat(var.arguments))) > 0 ? join(" ", var.arguments) : ""} ${length(compact(concat(var.envs))) > 0 ? join(" -e ", var.envs) : ""} ${var.playbook}"
   }
 
   lifecycle {
@@ -35,6 +35,4 @@ resource "null_resource" "cleanup" {
   provisioner "local-exec" {
     command = "rm -f ${data.archive_file.default.output_path}"
   }
-
-  depends_on = ["data.archive_file.default"]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,10 +1,10 @@
 variable "arguments" {
-  default = [""]
+  default = []
   type    = "list"
 }
 
 variable "envs" {
-  default = [""]
+  default = []
   type    = "list"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,12 +1,16 @@
 variable "arguments" {
-  type = "list"
+  default = [""]
+  type    = "list"
 }
 
 variable "envs" {
-  type = "list"
+  default = [""]
+  type    = "list"
 }
 
-variable "playbook" {}
+variable "playbook" {
+  default = ""
+}
 
 variable "dry_run" {
   default = true


### PR DESCRIPTION
## What

* Ansible provisioner shows pending changes each time 
* Make `arguments` and `envs` variables not required #14

## Why

* Module shouldn't rerun playbook if nothing has changed
* Keep everything DRY