### PR TITLE
Minimally update syntax for Terraform 0.12

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,7 @@ resource "null_resource" "provisioner" {
 
   depends_on = ["data.archive_file.default"]
 
-  triggers {
+  triggers = {
     signature = "${data.archive_file.default.output_md5}"
     command   = "ansible-playbook ${var.dry_run ? "--check --diff" : ""} ${join(" ", compact(var.arguments))} ${length(compact(var.envs)) > 0 ? "-e" : ""} ${join(" -e ", compact(var.envs))} ${var.playbook}"
   }
@@ -28,7 +28,7 @@ resource "null_resource" "provisioner" {
 }
 
 resource "null_resource" "cleanup" {
-  triggers {
+  triggers = {
     default = "${random_id.default.hex}"
   }
 


### PR DESCRIPTION
This change makes the Terraform module work using Terraform 0.12.  The module should still work with Terraform 0.11.

See [here](https://www.terraform.io/upgrade-guides/0-12.html#attributes-vs-blocks) for details.  The bit that is most relevant to this pull request is the paragraph that reads:
> Due to the design of the configuration language decoder in Terraform v0.11 and earlier, it was in many cases possible to interchange the argument syntax (with =) and the block syntax (with just braces) when dealing with map arguments vs. nested blocks. However, this led to some subtle bugs and limitations, so Terraform v0.12 now requires consistent usage of argument syntax for arguments and nested block syntax for nested blocks.