### PR TITLE
Fix warnings with terraform v0.12.17

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,9 @@ data "archive_file" "default" {
 resource "null_resource" "provisioner" {
   count = "${signum(length(var.playbook)) == 1 ? 1 : 0}"
 
-  depends_on = data.archive_file.default
+  depends_on = [
+    data.archive_file.default,
+  ]
 
   triggers = {
     signature = "${data.archive_file.default.output_md5}"

--- a/main.tf
+++ b/main.tf
@@ -4,19 +4,19 @@ resource "random_id" "default" {
 
 data "archive_file" "default" {
   type        = "zip"
-  source_dir  = "${dirname(var.playbook)}"
+  source_dir  = dirname(var.playbook)
   output_path = "${path.module}/${random_id.default.hex}.zip"
 }
 
 resource "null_resource" "provisioner" {
-  count = "${signum(length(var.playbook)) == 1 ? 1 : 0}"
+  count = signum(length(var.playbook)) == 1 ? 1 : 0
 
   depends_on = [
     data.archive_file.default,
   ]
 
   triggers = {
-    signature = "${data.archive_file.default.output_md5}"
+    signature = data.archive_file.default.output_md5
     command   = "ansible-playbook ${var.dry_run ? "--check --diff" : ""} ${join(" ", compact(var.arguments))} ${length(compact(var.envs)) > 0 ? "-e" : ""} ${join(" -e ", compact(var.envs))} ${var.playbook}"
   }
 
@@ -31,7 +31,7 @@ resource "null_resource" "provisioner" {
 
 resource "null_resource" "cleanup" {
   triggers = {
-    default = "${random_id.default.hex}"
+    default = random_id.default.hex
   }
 
   provisioner "local-exec" {

--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ data "archive_file" "default" {
 resource "null_resource" "provisioner" {
   count = "${signum(length(var.playbook)) == 1 ? 1 : 0}"
 
-  depends_on = ["data.archive_file.default"]
+  depends_on = data.archive_file.default
 
   triggers = {
     signature = "${data.archive_file.default.output_md5}"

--- a/variables.tf
+++ b/variables.tf
@@ -1,21 +1,21 @@
 variable "arguments" {
-  default = []
-  type    = "list"
+  default     = []
+  type        = list
   description = "Arguments"
 }
 
 variable "envs" {
-  default = []
-  type    = "list"
+  default     = []
+  type        = list
   description = "Environment variables"
 }
 
 variable "playbook" {
-  default = ""
+  default     = ""
   description = "Playbook to run"
 }
 
 variable "dry_run" {
-  default = true
+  default     = true
   description = "Do dry run"
 }


### PR DESCRIPTION
After updating to the latest terraform I ended up with a few warnings complaining about quoted interpolations being deprecated. This PR addresses those warnings for a clean init/apply output :smiley:.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cloudposse/terraform-null-ansible/24)
<!-- Reviewable:end -->
