### PR TITLE
Terraform 0.12+ syntax update

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,17 +4,17 @@ resource "random_id" "default" {
 
 data "archive_file" "default" {
   type        = "zip"
-  source_dir  = "${dirname(var.playbook)}"
+  source_dir  = dirname(var.playbook)
   output_path = "${path.module}/${random_id.default.hex}.zip"
 }
 
 resource "null_resource" "provisioner" {
-  count = "${signum(length(var.playbook)) == 1 ? 1 : 0}"
+  count = signum(length(var.playbook)) == 1 ? 1 : 0
 
-  depends_on = ["data.archive_file.default"]
+  depends_on = [data.archive_file.default]
 
   triggers = {
-    signature = "${data.archive_file.default.output_md5}"
+    signature = data.archive_file.default.output_md5
     command   = "ansible-playbook ${var.dry_run ? "--check --diff" : ""} ${join(" ", compact(var.arguments))} ${length(compact(var.envs)) > 0 ? "-e" : ""} ${join(" -e ", compact(var.envs))} ${var.playbook}"
   }
 
@@ -29,7 +29,7 @@ resource "null_resource" "provisioner" {
 
 resource "null_resource" "cleanup" {
   triggers = {
-    default = "${random_id.default.hex}"
+    default = random_id.default.hex
   }
 
   provisioner "local-exec" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,9 +1,9 @@
 output "arguments" {
-  value = "${var.arguments}"
+  value       = var.arguments
   description = "Arguments"
 }
 
 output "envs" {
-  value = "${var.envs}"
+  value       = var.envs
   description = "Environment variables"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,21 +1,21 @@
 variable "arguments" {
-  default = []
-  type    = "list"
+  default     = []
+  type        = list(string)
   description = "Arguments"
 }
 
 variable "envs" {
-  default = []
-  type    = "list"
+  default     = []
+  type        = list(string)
   description = "Environment variables"
 }
 
 variable "playbook" {
-  default = ""
+  default     = ""
   description = "Playbook to run"
 }
 
 variable "dry_run" {
-  default = true
+  default     = true
   description = "Do dry run"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    archive = {
+      version = "~> 2.2.0"
+    }
+    null = {
+      version = "~> 3.1.0"
+    }
+    random = {
+      version = "~> 3.1.0"
+    }
+  }
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
This change makes the module more compatible with Terraform 0.12+ and makes it fully compatible with Terraform 0.15.

More specifically, it gets rid of the _Invalid quoted type constraints_ deprecation errors.

Unfortunately, this syntax change makes the module incompatible with Terraform 0.11 and below. The minimum version is reflected in the `versions.tf` file along with required module version pinning.